### PR TITLE
Explicitly call rmSync.

### DIFF
--- a/initialize.js
+++ b/initialize.js
@@ -35,7 +35,7 @@ function fundAll() {
 
 function removeFiles(pattern) {
   console.log(`remove ${pattern}`);
-  glob(pattern).forEach(rmSync);
+  glob(pattern).forEach((entry) => rmSync(entry));
 }
 
 function buildAll() {


### PR DESCRIPTION
Passing the function straight to `forEach` will fail as unexpect params will also be passed through.