### PR TITLE
No need to fund accounts manually.

### DIFF
--- a/initialize.js
+++ b/initialize.js
@@ -30,7 +30,6 @@ function exe(command) {
 
 function fundAll() {
   exe(`${cli} keys generate ${process.env.SOROBAN_ACCOUNT}`);
-  exe(`${cli} keys fund ${process.env.SOROBAN_ACCOUNT}`);
 }
 
 function removeFiles(pattern) {


### PR DESCRIPTION
Account are funded automatically by `stellar keys generate` by default.

```console
$ stellar keys generate bob --network testnet

$ stellar keys address bob
GBIJVGHRP7HESNW6IBRBNPW6TNX6XUKRSPYCBUK725ZOKHHGU5YFTQC7

$ http https://horizon-testnet.stellar.org/accounts/GBIJVGHRP7HESNW6IBRBNPW6TNX6XUKRSPYCBUK725ZOKHHGU5YFTQC7 | jq .id
"GBIJVGHRP7HESNW6IBRBNPW6TNX6XUKRSPYCBUK725ZOKHHGU5YFTQC7"
```