### PR TITLE
fix(init): fund existing accounts; update contractsDir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Prefix with "PUBLIC_" to make available in Astro frontend files
-PUBLIC_SOROBAN_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
-PUBLIC_SOROBAN_RPC_URL="http://localhost:8000/soroban/rpc"
+PUBLIC_STELLAR_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+PUBLIC_STELLAR_RPC_URL="http://localhost:8000/soroban/rpc"
 
-SOROBAN_ACCOUNT="alice"
-SOROBAN_NETWORK="standalone"
+STELLAR_ACCOUNT="alice"
+STELLAR_NETWORK="standalone"


### PR DESCRIPTION
- if accounts already exist,
  - don't panic (that's the `| true`)
  - fund them
- use `.stellar` directory, not `.soroban` (and extract to a variable)
- rm unused `id` var
- build contracts after binding
- switch to `STELLAR_*` env vars, rather than obsolete `SOROBAN_*`