### PR TITLE
Update env vars in utils.ts to use STELLAR-* instead of SOROBAN-*

### DIFF
--- a/src/contracts/util.ts
+++ b/src/contracts/util.ts
@@ -1,2 +1,2 @@
-export const rpcUrl = import.meta.env.PUBLIC_SOROBAN_RPC_URL ?? "http://localhost:8000/rpc"
-export const networkPassphrase = import.meta.env.PUBLIC_SOROBAN_NETWORK_PASSPHRASE ?? "Standalone Network ; February 2017"
+export const rpcUrl = import.meta.env.PUBLIC_STELLAR_RPC_URL ?? "http://localhost:8000/rpc"
+export const networkPassphrase = import.meta.env.PUBLIC_STELLAR_NETWORK_PASSPHRASE ?? "Standalone Network ; February 2017"


### PR DESCRIPTION
We switched to using `STELLAR_*` env vars over `SOROBAN_` in a previous PR, and this is making sure to use those env vars in `contracts/utils.ts`